### PR TITLE
deploy: use commit hash + timestamp for image tag

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -34,6 +34,8 @@ build_image() {
     # build container image for dev or prod environments
 
     local environment="${1?No environment passed}"
+    local git_hash="$(git rev-parse --short HEAD)"
+    local timestamp="$(date +%Y%m%d%H%M%S)"
 
     if [[ "$environment" == "devel" ]]
     then
@@ -42,9 +44,9 @@ build_image() {
         docker build -t buildpack-admission:latest .
     else
         # Build the container image on the docker-builder host (currently tools-docker-imagebuilder-01.tools.eqiad1.wikimedia.cloud).
-        docker build . -f Dockerfile -t docker-registry.tools.wmflabs.org/buildpack-admission:latest
+        docker build . -f Dockerfile -t "docker-registry.tools.wmflabs.org/buildpack-admission:${timestamp}_${git_hash}"
         # Push the image to the internal repo
-        docker push docker-registry.tools.wmflabs.org/buildpack-admission:latest
+        docker push "docker-registry.tools.wmflabs.org/buildpack-admission:${timestamp}_${git_hash}"
         echo "Successfully built container image for tools/toolsbeta environments with exit code 0. \
         To deploy,log into k8s control node with repository checked out and run './deploy.sh (tools or toolsbeta)'"
     fi

--- a/deploy/tools/kustomization.yaml
+++ b/deploy/tools/kustomization.yaml
@@ -13,4 +13,4 @@ patchesJson6902:
 images:
   - name: buildpack-admission
     newName: docker-registry.tools.wmflabs.org/buildpack-admission
-    newTag: 8fe5685
+    newTag: 20221104141231_c15ea2e

--- a/deploy/toolsbeta/kustomization.yaml
+++ b/deploy/toolsbeta/kustomization.yaml
@@ -13,4 +13,4 @@ patchesJson6902:
 images:
   - name: buildpack-admission
     newName: docker-registry.tools.wmflabs.org/buildpack-admission
-    newTag: 8fe5685
+    newTag: 20221104141231_c15ea2e


### PR DESCRIPTION
This allows to determine which image we are using for which environment instead of a rolling latest.

Bug: T322413