### PR TITLE
deploy: don't use spaces when joining values

### DIFF
--- a/deployment/chart/templates/deployment.yaml
+++ b/deployment/chart/templates/deployment.yaml
@@ -26,9 +26,9 @@ spec:
             - name: "DEBUG"
               value: "{{ .Values.config.debug }}"
             - name: "ALLOWEDDOMAINS"
-              value: "{{ .Values.config.harborDomains | join ", " }}"
+              value: "{{ .Values.config.harborDomains | join "," }}"
             - name: "SYSTEMUSERS"
-              value: "{{ .Values.config.systemusers | join ", " }}"
+              value: "{{ .Values.config.systemusers | join "," }}"
           resources: {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: webhook-certs

--- a/deployment/chart/values.yaml
+++ b/deployment/chart/values.yaml
@@ -23,6 +23,6 @@ config:
   harborDomains:
     - harbor.toolforge.org
     - harbor.toolsbeta.wmflabs.org
-  
+
   systemUsers:
     - "system:serviceaccount:tekton-pipelines:tekton-pipelines-controller"


### PR DESCRIPTION
As they are parsed by the envconfig, the values are not trimmed for
trailing or preceding spaces.