### PR TITLE
validateadmission: add tool- prefix to harbor namespaces

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     -   id: trailing-whitespace
     -   id: end-of-file-fixer
     -   id: check-yaml
+        exclude: ^deployment/chart/templates/.*\.yaml$
     -   id: check-shebang-scripts-are-executable
     -   id: check-executables-have-shebangs
     -   id: check-merge-conflict

--- a/deployment/utils/local-values.sh
+++ b/deployment/utils/local-values.sh
@@ -4,7 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-cat > $(dirname $0)/../values/local.yaml <<EOF
+cat > "$(dirname "$0")"/../values/local.yaml <<EOF
 image:
   name: buildpack-admission
   tag: latest

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2,7 +2,7 @@ package server
 
 import (
 	"crypto/tls"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/sirupsen/logrus"
@@ -30,7 +30,7 @@ type AdmissionControllerServer struct {
 
 func (acs *AdmissionControllerServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var body []byte
-	if data, err := ioutil.ReadAll(r.Body); err == nil {
+	if data, err := io.ReadAll(r.Body); err == nil {
 		body = data
 	}
 	logrus.Debugln(string(body))

--- a/pkg/server/validateadmission.go
+++ b/pkg/server/validateadmission.go
@@ -54,7 +54,7 @@ func (p *PipelineRunAdmission) HandleAdmission(review *admissionv1.AdmissionRevi
 		}
 	}
 	for _, param := range pipelinerun.Spec.Params {
-		expectedURL := fmt.Sprintf("^(https?://)?%s/%s/", domstr, user)
+		expectedURL := fmt.Sprintf("^(https?://)?%s/tool-%s/", domstr, user)
 		harborRe := regexp.MustCompile(expectedURL)
 		logrus.Debugf("Found PipeLineRun param: %v", param.Name)
 		switch param.Name {


### PR DESCRIPTION
* refactor validateadmission.go to include "tool-" in the "expectedURL" regex
* get server_test.go tests to pass
* exclude deployment/chart/templates/* from pre-commit because of the templating syntax
* fix pre-commit ioutil deprecation error
    
Bug: T334657